### PR TITLE
Add responsive Portfolio section

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,6 +51,28 @@
               <p>Я опытный продуктовый дизайнер, специализируюсь на создании интерфейсов для web- и мобильных приложений, создании дизайн-систем и управлении командой. Реализовал проекты, которые улучшили пользовательский опыт и бизнес-метрики. Стремлюсь к балансу между задачами бизнеса и ожиданиями пользователей.</p>
               <a href="#resume">Скачать резюме</a>
       </section>
+
+      <section id="portfolio" class="portfolio">
+        <h2>Портфолио</h2>
+        <div class="portfolio-grid">
+          <article class="portfolio-card">
+            <div class="portfolio-card__image"></div>
+            <h3 class="portfolio-card__title">Проект 1</h3>
+          </article>
+          <article class="portfolio-card">
+            <div class="portfolio-card__image"></div>
+            <h3 class="portfolio-card__title">Проект 2</h3>
+          </article>
+          <article class="portfolio-card">
+            <div class="portfolio-card__image"></div>
+            <h3 class="portfolio-card__title">Проект 3</h3>
+          </article>
+          <article class="portfolio-card">
+            <div class="portfolio-card__image"></div>
+            <h3 class="portfolio-card__title">Проект 4</h3>
+          </article>
+        </div>
+      </section>
   </main>
 </div>
 

--- a/styles.css
+++ b/styles.css
@@ -233,3 +233,41 @@ section {
    max-width: 1440px;
    margin: 0 auto;
  }
+
+/* ===========================
+   PORTFOLIO SECTION
+   =========================== */
+.portfolio {
+  padding: 0 20px;
+  max-width: 1440px;
+  margin: 40px auto 0;
+  box-sizing: border-box;
+}
+
+.portfolio-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  row-gap: 16px;
+}
+
+.portfolio-card__image {
+  background-color: var(--background-alt);
+  width: 100%;
+  aspect-ratio: 1 / 1;
+}
+
+.portfolio-card__title {
+  margin-top: 8px;
+}
+
+@media (min-width: 768px) {
+  .portfolio {
+    padding: 0 80px;
+  }
+
+  .portfolio-grid {
+    grid-template-columns: 1fr 1fr;
+    column-gap: 24px;
+    row-gap: 24px;
+  }
+}


### PR DESCRIPTION
## Summary
- add portfolio grid to the page
- style portfolio cards with responsive padding and square images

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686bb840a748832aa5b912950ed8b21c