### PR TITLE
Add responsive Portfolio section

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,11 +45,35 @@
 
   <div class="wrapper">
     <main>
-      <section>
+      <section class="welcome">
             <img src="src/ava.png" alt="Pavel Yasmenko" class="welcome__avatar" />
               <h3>Привет! Я Павел, продуктовый дизайнер.</h3>
               <p>Я опытный продуктовый дизайнер, специализируюсь на создании интерфейсов для web- и мобильных приложений, создании дизайн-систем и управлении командой. Реализовал проекты, которые улучшили пользовательский опыт и бизнес-метрики. Стремлюсь к балансу между задачами бизнеса и ожиданиями пользователей.</p>
               <a href="#resume">Скачать резюме</a>
+      </section>
+
+      <section id="portfolio" class="portfolio">
+        <h3>Портфолио</h3>
+        <div class="portfolio-grid">
+          <article class="portfolio-card">
+            <div class="portfolio-card__image"></div>
+          </article>
+          <article class="portfolio-card">
+            <div class="portfolio-card__image"></div>
+          </article>
+          <article class="portfolio-card">
+            <div class="portfolio-card__image"></div>
+          </article>
+          <article class="portfolio-card">
+            <div class="portfolio-card__image"></div>
+          </article>
+          <article class="portfolio-card">
+            <div class="portfolio-card__image"></div>
+          </article>
+          <article class="portfolio-card">
+            <div class="portfolio-card__image"></div>
+          </article>
+        </div>
       </section>
   </main>
 </div>

--- a/styles.css
+++ b/styles.css
@@ -128,7 +128,8 @@ body {
    WELCOME SECTION (avatar + text)
    =========================== */
 /* Мобильная версия (<768px) */
-section {
+/* Styles for the welcome section */
+.welcome {
   display: block;
   padding: 0 20px;
   margin-top: 20px;   /* добавили отступ сверху для мобилки */
@@ -141,14 +142,14 @@ section {
 }
 
 @media (max-width: 767px) {
-  section > h3 {
+  .welcome > h3 {
     margin-top: 0;                          /* сброс «наложения» маржинов */
   }
 }
 
 /* Десктоп (≥768px) */
 @media (min-width: 768px) {
-  section {
+  .welcome {
     display: grid;
     grid-template-columns: 200px 1fr;
     grid-template-rows: auto auto auto;
@@ -165,17 +166,17 @@ section {
     margin: 0;
   }
 
-  section > h3 {
+  .welcome > h3 {
     grid-column: 2;
     grid-row: 1;
     margin: 0 0 0.5em;
   }
-  section > p {
+  .welcome > p {
     grid-column: 2;
     grid-row: 2;
     margin: 0 0 1em;
   }
-  section > a {
+  .welcome > a {
     grid-column: 2;
     grid-row: 3;
   }
@@ -233,3 +234,42 @@ section {
    max-width: 1440px;
    margin: 0 auto;
  }
+
+/* ===========================
+   PORTFOLIO SECTION
+   =========================== */
+.portfolio {
+  padding: 0 20px;
+  max-width: 1440px;
+  margin: 40px auto 0;
+  box-sizing: border-box;
+}
+
+.portfolio-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  row-gap: 16px;
+}
+
+.portfolio-card__image {
+  background-color: var(--background-alt);
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  border-radius: 32px;
+}
+
+.portfolio h3 {
+  margin: 0 0 32px;
+}
+
+@media (min-width: 768px) {
+  .portfolio {
+    padding: 0 80px;
+  }
+
+  .portfolio-grid {
+    grid-template-columns: 1fr 1fr;
+    column-gap: 24px;
+    row-gap: 24px;
+  }
+}


### PR DESCRIPTION
## Summary
- add portfolio grid to the page
- style portfolio cards with responsive padding and square images
- update portfolio grid styling
- fix portfolio layout by scoping welcome section styles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686bb840a748832aa5b912950ed8b21c