### PR TITLE
Fix contacts heading style

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,7 +75,9 @@
           </article>
         </div>
       </section>
-      <h3 id="contacts">Контакты</h3>
+      <section id="contacts" class="contacts">
+        <h2>Контакты</h2>
+      </section>
   </main>
 </div>
 

--- a/styles.css
+++ b/styles.css
@@ -279,3 +279,24 @@ body {
     margin-bottom: 32px;
   }
 }
+
+/* ===========================
+   CONTACTS SECTION
+   =========================== */
+.contacts {
+  padding: 0 20px;
+  max-width: 1440px;
+  margin: 40px auto 0;
+  box-sizing: border-box;
+}
+
+.contacts > h2 {
+  margin-top: 0;
+}
+
+@media (min-width: 768px) {
+  .contacts {
+    padding: 0 80px;
+    margin-top: 60px;
+  }
+}


### PR DESCRIPTION
## Summary
- switch contacts heading to `<h2>` and wrap it in a new section
- style new contacts section so it aligns with the page content

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686e5baef470832a8c69479e352d439e