### PR TITLE
Add image and skeleton loader to portfolio cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,22 +56,34 @@
         <h2>Портфолио</h2>
         <div class="portfolio-grid">
           <article class="portfolio-card">
-            <div class="portfolio-card__image"></div>
+            <div class="portfolio-card__image">
+              <img src="https://files.catbox.moe/uzq4gw.png" alt="Пример работы" loading="lazy" />
+            </div>
           </article>
           <article class="portfolio-card">
-            <div class="portfolio-card__image"></div>
+            <div class="portfolio-card__image">
+              <img src="https://files.catbox.moe/uzq4gw.png" alt="Пример работы" loading="lazy" />
+            </div>
           </article>
           <article class="portfolio-card">
-            <div class="portfolio-card__image"></div>
+            <div class="portfolio-card__image">
+              <img src="https://files.catbox.moe/uzq4gw.png" alt="Пример работы" loading="lazy" />
+            </div>
           </article>
           <article class="portfolio-card">
-            <div class="portfolio-card__image"></div>
+            <div class="portfolio-card__image">
+              <img src="https://files.catbox.moe/uzq4gw.png" alt="Пример работы" loading="lazy" />
+            </div>
           </article>
           <article class="portfolio-card">
-            <div class="portfolio-card__image"></div>
+            <div class="portfolio-card__image">
+              <img src="https://files.catbox.moe/uzq4gw.png" alt="Пример работы" loading="lazy" />
+            </div>
           </article>
           <article class="portfolio-card">
-            <div class="portfolio-card__image"></div>
+            <div class="portfolio-card__image">
+              <img src="https://files.catbox.moe/uzq4gw.png" alt="Пример работы" loading="lazy" />
+            </div>
           </article>
         </div>
       </section>
@@ -82,7 +94,7 @@
         <p>pyasmenko@mail.ru</p>
       </section>
   </main>
-</div>
-
-</body>
+  </div>
+  <script src="scripts.js"></script>
+ </body>
 </html>

--- a/scripts.js
+++ b/scripts.js
@@ -1,0 +1,17 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const containers = document.querySelectorAll('.portfolio-card__image');
+  containers.forEach((container) => {
+    const img = container.querySelector('img');
+    if (!img) return;
+    function onLoad() {
+      container.classList.add('loaded');
+    }
+    if (img.complete) {
+      onLoad();
+    } else {
+      img.addEventListener('load', onLoad);
+      img.addEventListener('error', onLoad);
+    }
+  });
+});
+

--- a/styles.css
+++ b/styles.css
@@ -264,6 +264,45 @@ body {
   width: 100%;
   aspect-ratio: 1 / 1;
   border-radius: 32px;
+  position: relative;
+  overflow: hidden;
+}
+
+.portfolio-card__image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: inherit;
+  display: block;
+  opacity: 0;
+  transition: opacity 0.3s ease-in-out;
+}
+
+.portfolio-card__image::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, var(--background-alt) 0%, var(--background) 50%, var(--background-alt) 100%);
+  background-size: 200% 100%;
+  animation: skeleton-loading 1.5s infinite;
+}
+
+.portfolio-card__image.loaded::before {
+  opacity: 0;
+  animation: none;
+}
+
+.portfolio-card__image.loaded img {
+  opacity: 1;
+}
+
+@keyframes skeleton-loading {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
 }
 
 @media (min-width: 768px) {


### PR DESCRIPTION
## Summary
- show the same image on all portfolio cards
- add skeleton loading animation
- hide skeleton once image has loaded with JS

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6870eb457200832abf0681ec9babfdca