### PR TITLE
Add hover titles to portfolio cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,31 +58,55 @@
           <article class="portfolio-card">
             <div class="portfolio-card__image">
               <img src="https://files.catbox.moe/wndbst.png" alt="Пример работы" loading="lazy" />
+              <div class="portfolio-card__overlay">
+                <h3 class="title-desktop">Заголовок карточки кейса</h3>
+                <h4 class="title-mobile">Заголовок карточки кейса</h4>
+              </div>
             </div>
           </article>
           <article class="portfolio-card">
             <div class="portfolio-card__image">
               <img src="https://files.catbox.moe/3iruxk.png" alt="Пример работы" loading="lazy" />
+              <div class="portfolio-card__overlay">
+                <h3 class="title-desktop">Заголовок карточки кейса</h3>
+                <h4 class="title-mobile">Заголовок карточки кейса</h4>
+              </div>
             </div>
           </article>
           <article class="portfolio-card">
             <div class="portfolio-card__image">
               <img src="https://placehold.co/700" alt="Пример работы" loading="lazy" />
+              <div class="portfolio-card__overlay">
+                <h3 class="title-desktop">Заголовок карточки кейса</h3>
+                <h4 class="title-mobile">Заголовок карточки кейса</h4>
+              </div>
             </div>
           </article>
           <article class="portfolio-card">
             <div class="portfolio-card__image">
               <img src="https://placehold.co/700" alt="Пример работы" loading="lazy" />
+              <div class="portfolio-card__overlay">
+                <h3 class="title-desktop">Заголовок карточки кейса</h3>
+                <h4 class="title-mobile">Заголовок карточки кейса</h4>
+              </div>
             </div>
           </article>
           <article class="portfolio-card">
             <div class="portfolio-card__image">
               <img src="https://placehold.co/700" alt="Пример работы" loading="lazy" />
+              <div class="portfolio-card__overlay">
+                <h3 class="title-desktop">Заголовок карточки кейса</h3>
+                <h4 class="title-mobile">Заголовок карточки кейса</h4>
+              </div>
             </div>
           </article>
           <article class="portfolio-card">
             <div class="portfolio-card__image">
               <img src="https://placehold.co/700" alt="Пример работы" loading="lazy" />
+              <div class="portfolio-card__overlay">
+                <h3 class="title-desktop">Заголовок карточки кейса</h3>
+                <h4 class="title-mobile">Заголовок карточки кейса</h4>
+              </div>
             </div>
           </article>
         </div>

--- a/styles.css
+++ b/styles.css
@@ -268,6 +268,46 @@ body {
   overflow: hidden;
 }
 
+.portfolio-card__overlay {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  padding: 8px;
+  background: linear-gradient(to top, var(--background) 0%, transparent 100%);
+  color: #fff;
+  box-sizing: border-box;
+}
+
+.title-desktop {
+  display: none;
+  margin: 0;
+}
+
+.title-mobile {
+  margin: 0;
+}
+
+@media (min-width: 768px) {
+  .portfolio-card__overlay {
+    padding: 16px;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+  }
+
+  .portfolio-card:hover .portfolio-card__overlay {
+    opacity: 1;
+  }
+
+  .title-desktop {
+    display: block;
+  }
+
+  .title-mobile {
+    display: none;
+  }
+}
+
 .portfolio-card__image img {
   width: 100%;
   height: 100%;


### PR DESCRIPTION
## Summary
- overlay titles and fade added to portfolio cards
- show h4 on mobile, h3 on desktop with hover effect

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68711e882418832aa35be44db8561cde