### PR TITLE
Show card overlay text and add hover zoom

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -307,13 +307,10 @@ body {
     left: 8px;
     right: 8px;
     bottom: 8px;
-    opacity: 0;
-    transition: opacity 0.3s ease;
-  }
-
-  .portfolio-card:hover .portfolio-card__overlay {
     opacity: 1;
   }
+
+
 
   .title-desktop {
     display: block;
@@ -331,7 +328,11 @@ body {
   border-radius: inherit;
   display: block;
   opacity: 0;
-  transition: opacity 0.3s ease-in-out;
+  transition: opacity 0.3s ease-in-out, transform 0.3s ease;
+}
+
+.portfolio-card:hover .portfolio-card__image img {
+  transform: scale(1.02);
 }
 
 .portfolio-card__image::before {


### PR DESCRIPTION
## Summary
- keep overlay visible on desktop cards
- scale card images slightly on hover

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687560e13194832a8379c3cb6039651f