### PR TITLE
Implement modal window for portfolio cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,6 +109,18 @@
       </section>
   </main>
   </div>
+
+  <div id="modal-overlay" class="modal-overlay"></div>
+  <div id="modal" class="modal">
+    <button id="modal-close" class="modal-close" aria-label="Закрыть">
+      <img src="src/Burger_close.svg" alt="Закрыть" />
+    </button>
+    <div class="modal-content">
+      <h2>Заголовок</h2>
+      <p>Подзаголовок</p>
+    </div>
+  </div>
+
   <script src="scripts.js"></script>
  </body>
 </html>

--- a/scripts.js
+++ b/scripts.js
@@ -13,5 +13,28 @@ document.addEventListener('DOMContentLoaded', () => {
       img.addEventListener('error', onLoad);
     }
   });
+
+  const modal = document.getElementById('modal');
+  const overlay = document.getElementById('modal-overlay');
+  const closeBtn = document.getElementById('modal-close');
+
+  function openModal() {
+    modal.classList.add('active');
+    overlay.classList.add('active');
+    document.body.style.overflow = 'hidden';
+  }
+
+  function closeModal() {
+    modal.classList.remove('active');
+    overlay.classList.remove('active');
+    document.body.style.overflow = '';
+  }
+
+  cards.forEach((card) => {
+    card.addEventListener('click', openModal);
+  });
+
+  overlay.addEventListener('click', closeModal);
+  closeBtn.addEventListener('click', closeModal);
 });
 

--- a/styles.css
+++ b/styles.css
@@ -414,3 +414,60 @@ body {
     margin-bottom: 60px;
   }
 }
+
+/* ===========================
+   MODAL
+   =========================== */
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: none;
+  z-index: 100;
+}
+
+.modal-overlay.active {
+  display: block;
+}
+
+.modal {
+  position: fixed;
+  left: 0;
+  right: 0;
+  top: 20px;
+  margin: 0 auto;
+  width: 100%;
+  max-width: 1024px;
+  background: var(--background-body);
+  border-radius: 16px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+  padding: 20px;
+  box-sizing: border-box;
+  display: none;
+  z-index: 101;
+}
+
+@media (min-width: 768px) {
+  .modal {
+    top: 40px;
+  }
+}
+
+.modal.active {
+  display: block;
+}
+
+.modal-close {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+
+.modal-close img {
+  width: 24px;
+  height: 24px;
+}


### PR DESCRIPTION
## Summary
- add modal markup and overlay
- style modal for mobile and desktop
- implement JS logic to open/close modal

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6877527e115c832aafc48d12c8d8e08b