### PR TITLE
Add lazyload skeleton for modal images

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -28,6 +28,19 @@ document.addEventListener('DOMContentLoaded', () => {
         }
       }
 
+      const images = modal.querySelectorAll('.modal-content img');
+      images.forEach((img) => {
+        function onImgLoad() {
+          img.classList.add('loaded');
+        }
+        if (img.complete) {
+          onImgLoad();
+        } else {
+          img.addEventListener('load', onImgLoad);
+          img.addEventListener('error', onImgLoad);
+        }
+      });
+
       if (window.innerWidth < 768) {
         const firstHeading = modal.querySelector('.modal-content h1');
         if (firstHeading) {

--- a/styles.css
+++ b/styles.css
@@ -529,4 +529,18 @@ body {
 .modal-content img {
   margin-top: 17px;
   margin-bottom: 17px;
+  width: 100%;
+  height: auto;
+  display: block;
+  opacity: 0;
+  transition: opacity 0.3s ease-in-out;
+  background: linear-gradient(90deg, var(--background-alt) 0%, var(--background) 50%, var(--background-alt) 100%);
+  background-size: 200% 100%;
+  animation: skeleton-loading 1.5s infinite;
+}
+
+.modal-content img.loaded {
+  opacity: 1;
+  animation: none;
+  background: none;
 }


### PR DESCRIPTION
## Summary
- add skeleton animation for images inside modals
- mark modal images as loaded when image elements finish loading

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687b9d53cc6c832a90ca813fcfd027c6