### PR TITLE
Fix skeleton placeholder for modal images

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -28,6 +28,20 @@ document.addEventListener('DOMContentLoaded', () => {
         }
       }
 
+      const images = modal.querySelectorAll('.modal-content img');
+      images.forEach((img) => {
+        function onImgLoad() {
+          img.classList.add('loaded');
+        }
+
+        if (img.complete && img.naturalWidth !== 0) {
+          onImgLoad();
+        } else {
+          img.addEventListener('load', onImgLoad, { once: true });
+          img.addEventListener('error', onImgLoad, { once: true });
+        }
+      });
+
       if (window.innerWidth < 768) {
         const firstHeading = modal.querySelector('.modal-content h1');
         if (firstHeading) {

--- a/styles.css
+++ b/styles.css
@@ -529,4 +529,20 @@ body {
 .modal-content img {
   margin-top: 17px;
   margin-bottom: 17px;
+  width: 100%;
+  height: auto;
+  display: block;
+  opacity: 0;
+  min-height: 200px;
+  transition: opacity 0.3s ease-in-out;
+  background: linear-gradient(90deg, var(--background-alt) 0%, var(--background) 50%, var(--background-alt) 100%);
+  background-size: 200% 100%;
+  animation: skeleton-loading 1.5s infinite;
+}
+
+.modal-content img.loaded {
+  opacity: 1;
+  min-height: 0;
+  animation: none;
+  background: none;
 }


### PR DESCRIPTION
## Summary
- ensure modal images have placeholder height so skeleton animation shows
- handle cached images correctly by checking naturalWidth before marking them loaded

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687b9d53cc6c832a90ca813fcfd027c6