### PR TITLE
Add video skeleton loading support

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,6 +50,9 @@
               <h3>Привет! Я Павел, продуктовый дизайнер</h3>
               <p>У меня сильная экспертиза в&nbsp;e-commerce и веб-сервисах. Разрабатывал интерфейсы для МТС и Otto Group, участвовал в запуске крупных фич и&nbsp;редизайнах, улучшал UX на основе данных и исследований. Реализовал проекты, которые улучшили бизнес-метрики. Работаю автономно, помогаю выстраивать процессы в команде.</p>
               <a href="src/Resume_Yasmenko_Pavel.pdf" target="_blank" rel="noopener noreferrer">Смотреть резюме</a>
+              <div class="video-wrapper">
+                <iframe src="https://player.vimeo.com/video/000000000" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
+              </div>
       </section>
 
       <section id="portfolio" class="portfolio">

--- a/scripts.js
+++ b/scripts.js
@@ -18,6 +18,13 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
+  const iframes = document.querySelectorAll('.video-wrapper iframe');
+  iframes.forEach((iframe) => {
+    iframe.addEventListener('load', () => {
+      iframe.parentElement.classList.add('loaded');
+    });
+  });
+
   const modal = document.getElementById('modal');
   const overlay = document.getElementById('modal-overlay');
   const closeBtn = document.getElementById('modal-close');

--- a/styles.css
+++ b/styles.css
@@ -385,6 +385,44 @@ body {
   opacity: 1;
 }
 
+/* Skeleton loader for Vimeo video */
+.video-wrapper {
+  position: relative;
+  overflow: hidden;
+  padding-top: 56.25%;
+}
+
+.video-wrapper iframe {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+  opacity: 0;
+  transition: opacity 0.3s ease-in-out;
+}
+
+.video-wrapper::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  pointer-events: none;
+  background: linear-gradient(90deg, var(--background-alt) 0%, var(--background) 50%, var(--background-alt) 100%);
+  background-size: 200% 100%;
+  animation: skeleton-loading 1.5s infinite;
+  transition: opacity 0.3s ease-in-out;
+}
+
+.video-wrapper.loaded::before {
+  opacity: 0;
+  animation: none;
+}
+
+.video-wrapper.loaded iframe {
+  opacity: 1;
+}
+
 @keyframes skeleton-loading {
   0% {
     background-position: 200% 0;


### PR DESCRIPTION
## Summary
- style video skeleton loader
- fade in video iframe after load with JS
- add Vimeo iframe inside the welcome section

## Testing
- `grep -n "video-wrapper" -R`

------
https://chatgpt.com/codex/tasks/task_e_6881f36c3b1c832a88ec22d4445ef7d6