### PR TITLE
Fix modal scroll position on reopen

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -62,6 +62,10 @@ document.addEventListener('DOMContentLoaded', () => {
   function closeModal() {
     modal.classList.remove('active');
     overlay.classList.remove('active');
+    const content = modal.querySelector('.modal-content');
+    if (content) {
+      content.scrollTop = 0;
+    }
     document.body.style.overflow = '';
   }
 


### PR DESCRIPTION
## Summary
- reset the modal scroll position when closing

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68820066c220832aa67375781809172b