### PR TITLE
feat: open resume in modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
             <img src="src/ava.png" alt="Pavel Yasmenko" class="welcome__avatar" loading="lazy" />
               <h3>Привет! Я Павел, продуктовый дизайнер</h3>
               <p>У меня сильная экспертиза в&nbsp;e-commerce и веб-сервисах. Разрабатывал интерфейсы для МТС и Otto Group, участвовал в запуске крупных фич и&nbsp;редизайнах, повышал качество UX на основе данных и исследований. Реализовал проекты, которые улучшили бизнес-метрики. Работаю автономно, помогаю выстраивать процессы в команде.</p>
-              <a href="src/Resume_Yasmenko_Pavel.pdf" target="_blank" rel="noopener noreferrer">Смотреть резюме</a>
+              <a href="#" class="resume-link" data-modal-id="resume">Смотреть резюме</a>
       </section>
 
       <section id="portfolio" class="portfolio">
@@ -123,6 +123,10 @@
       <p>Подзаголовок</p>
     </div>
   </div>
+
+  <template id="resume">
+    <iframe src="src/Resume_Yasmenko_Pavel.pdf" title="Резюме" style="width:100%;height:100%;min-height:80vh;border:none;"></iframe>
+  </template>
 
   <template id="case-shop">
     <h1>Кейсы МТС Shop</h1>

--- a/scripts.js
+++ b/scripts.js
@@ -32,6 +32,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const closeBtn = document.getElementById('modal-close');
 
   function openModal(event) {
+    event.preventDefault();
     const card = event.currentTarget;
     const id = card.getAttribute('data-modal-id');
       if (id) {
@@ -81,6 +82,11 @@ document.addEventListener('DOMContentLoaded', () => {
   cards.forEach((card) => {
     card.addEventListener('click', openModal);
   });
+
+  const resumeLink = document.querySelector('.resume-link');
+  if (resumeLink) {
+    resumeLink.addEventListener('click', openModal);
+  }
 
   overlay.addEventListener('click', closeModal);
   closeBtn.addEventListener('click', closeModal);

--- a/styles.css
+++ b/styles.css
@@ -566,6 +566,13 @@ body {
   background: none;
 }
 
+.modal-content iframe {
+  width: 100%;
+  height: 100%;
+  min-height: 80vh;
+  border: none;
+}
+
 .video-wrapper {
   position: relative;
   padding-bottom: 71.11%;


### PR DESCRIPTION
## Summary
- show resume in existing modal layout
- load resume template on click and prevent default link navigation
- style iframe for full-size resume display

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68906df747c8832a8c073552acca72ea