### PR TITLE
Replace resume modal with direct PDF link

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
             <img src="src/ava.png" alt="Pavel Yasmenko" class="welcome__avatar" loading="lazy" />
               <h3>Привет! Я Павел, продуктовый дизайнер</h3>
               <p>У меня сильная экспертиза в&nbsp;e-commerce и веб-сервисах. Разрабатывал интерфейсы для МТС и Otto Group, участвовал в запуске крупных фич и&nbsp;редизайнах, повышал качество UX на основе данных и исследований. Реализовал проекты, которые улучшили бизнес-метрики. Работаю автономно, помогаю выстраивать процессы в команде.</p>
-              <a href="#" class="resume-link" data-modal-id="resume">Смотреть резюме</a>
+              <a href="src/Resume_Yasmenko_Pavel.pdf">Смотреть резюме</a>
       </section>
 
       <section id="portfolio" class="portfolio">
@@ -123,10 +123,6 @@
       <p>Подзаголовок</p>
     </div>
   </div>
-
-  <template id="resume">
-    <iframe src="src/Resume_Yasmenko_Pavel.pdf" title="Резюме" style="width:100%;height:100%;min-height:80vh;border:none;"></iframe>
-  </template>
 
   <template id="case-shop">
     <h1>Кейсы МТС Shop</h1>

--- a/scripts.js
+++ b/scripts.js
@@ -83,11 +83,6 @@ document.addEventListener('DOMContentLoaded', () => {
     card.addEventListener('click', openModal);
   });
 
-  const resumeLink = document.querySelector('.resume-link');
-  if (resumeLink) {
-    resumeLink.addEventListener('click', openModal);
-  }
-
   overlay.addEventListener('click', closeModal);
   closeBtn.addEventListener('click', closeModal);
 });


### PR DESCRIPTION
## Summary
- Remove resume modal template and link directly to PDF
- Drop JavaScript handler for resume modal

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68923c52eb28832a99e725a6e24905ee