### PR TITLE
Use local Vela Sans font

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,12 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Портфолио Ясменко Павел</title>
 
-  <!-- Google Fonts: Manrope -->
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link
-    href="https://fonts.googleapis.com/css2?family=Manrope:wght@200..800&display=swap"
-    rel="stylesheet"/>
+  <!-- Local font: Vela Sans defined in CSS -->
 
     <!-- Стили ватер -->
   <link rel="stylesheet" href="water_mod.css"/>

--- a/styles.css
+++ b/styles.css
@@ -1,5 +1,68 @@
+@font-face {
+  font-family: 'Vela Sans';
+  src: url('./Font/VelaSans-ExtraLight.woff2') format('woff2'),
+       url('./Font/VelaSans-ExtraLight.woff') format('woff');
+  font-weight: 200;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'Vela Sans';
+  src: url('./Font/VelaSans-Light.woff2') format('woff2'),
+       url('./Font/VelaSans-Light.woff') format('woff');
+  font-weight: 300;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'Vela Sans';
+  src: url('./Font/VelaSans-Regular.woff2') format('woff2'),
+       url('./Font/VelaSans-Regular.woff') format('woff');
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'Vela Sans';
+  src: url('./Font/VelaSans-Medium.woff2') format('woff2'),
+       url('./Font/VelaSans-Medium.woff') format('woff');
+  font-weight: 500;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'Vela Sans';
+  src: url('./Font/VelaSans-SemiBold.woff2') format('woff2'),
+       url('./Font/VelaSans-SemiBold.woff') format('woff');
+  font-weight: 600;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'Vela Sans';
+  src: url('./Font/VelaSans-Bold.woff2') format('woff2'),
+       url('./Font/VelaSans-Bold.woff') format('woff');
+  font-weight: 700;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'Vela Sans';
+  src: url('./Font/VelaSans-ExtraBold.woff2') format('woff2'),
+       url('./Font/VelaSans-ExtraBold.woff') format('woff');
+  font-weight: 800;
+  font-style: normal;
+  font-display: swap;
+}
+
 :root {
-  --font-sans: 'Manrope', sans-serif;
+  --font-sans: 'Vela Sans', sans-serif;
   /* Переменные ниже тут */
 }
 

--- a/water_mod.css
+++ b/water_mod.css
@@ -109,7 +109,7 @@ html {
 }
 
 body {
-  font-family: 'Manrope', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', 'Segoe UI Emoji', 'Apple Color Emoji', 'Noto Color Emoji', sans-serif;
+  font-family: 'Vela Sans', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', 'Segoe UI Emoji', 'Apple Color Emoji', 'Noto Color Emoji', sans-serif;
   line-height: 1.5;
   max-width: 1440px;
   margin: 20px auto;


### PR DESCRIPTION
## Summary
- replace Manrope with locally hosted Vela Sans font
- remove Google Fonts link and define @font-face rules for Vela Sans
- update base styles to use Vela Sans

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c083ea4958832a89fd18075ff782b2