### PR TITLE
Improve modal viewport height handling across devices

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -1,4 +1,14 @@
 document.addEventListener('DOMContentLoaded', () => {
+  function updateViewportHeight() {
+    document.documentElement.style.setProperty(
+      '--app-viewport-height',
+      `${window.innerHeight}px`
+    );
+  }
+
+  updateViewportHeight();
+  window.addEventListener('resize', updateViewportHeight);
+
   const cards = document.querySelectorAll('.portfolio-card');
   cards.forEach((card) => {
     const img = card.querySelector('.portfolio-card__image img');

--- a/styles.css
+++ b/styles.css
@@ -464,6 +464,8 @@ body {
   width: 100%;
   max-width: 1024px;
   max-height: 95vh;
+  max-height: min(95vh, calc(var(--app-viewport-height, 100vh) * 0.95));
+  max-height: min(95vh, 95svh);
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -477,6 +479,12 @@ body {
   transition: transform 0.3s ease-out, opacity 0.3s ease-out;
   pointer-events: none;
   z-index: 101;
+}
+
+@supports (height: 100dvh) {
+  .modal {
+    max-height: min(95dvh, calc(var(--app-viewport-height, 100dvh) * 0.95));
+  }
 }
 
 @media (min-width: 768px) {


### PR DESCRIPTION
## Summary
- cap the modal height with dynamic viewport units and add a dvh-specific override when supported
- provide a JavaScript-managed CSS variable fallback for browsers that lack small/large viewport units

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d922fc78f4832aaabfff1de89b5969